### PR TITLE
Ask for more bins

### DIFF
--- a/lib/vimaly/client.rb
+++ b/lib/vimaly/client.rb
@@ -64,7 +64,7 @@ module Vimaly
 
     def bins
       @bins ||= begin
-        get('/bins').map do |bin_data|
+        get('/bins?max-results=500').map do |bin_data|
           Bin.new(bin_data['_id'], bin_data['name'])
         end
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -210,7 +210,7 @@ class ClientTest < Minitest::Test
   private
 
   def stub_bins
-    stub_request(:get, "#{Vimaly::Client::VIMALY_ROOT_URL}/rest/1/company_id/bins").to_return(
+    stub_request(:get, %r{#{Vimaly::Client::VIMALY_ROOT_URL}/rest/1/company_id/bins}).to_return(
       status: 200,
       body: [{name: 'Alpha', _id: 1}, {name: 'Beta', _id: 2}]
     )


### PR DESCRIPTION
We currently have 248 bins in _vimaly_, but the REST API endpoint only returns 200 (on default). As Russell Healy pointed out in a chat, we can ask for more bins using the `max-results` http parameter.